### PR TITLE
housebankall no longer overwrites DoItAll.BankAll function, uses it's own now

### DIFF
--- a/src/HouseBankAll/Keybind.lua
+++ b/src/HouseBankAll/Keybind.lua
@@ -4,7 +4,7 @@ local keystripDef = {
     {
         name = "Transfer All",
         keybind = "SC_BANK_ALL",
-        callback = function() DoItAll.BankAll() end,
+        callback = function() DoItAll.HouseBankAll() end,
         alignment = KEYBIND_STRIP_ALIGN_LEFT,
     }
 }

--- a/src/HouseBankAll/Transfer.lua
+++ b/src/HouseBankAll/Transfer.lua
@@ -35,7 +35,7 @@ local function TransferAll(container)
 	if errorMessage then ReportError() end
 end
 
-function DoItAll.BankAll()
+function DoItAll.HouseBankAll()
 	if HOUSE_BANK_FRAGMENT.state == SCENE_SHOWN then
 		TransferAll(ZO_HouseBankBackpack)
 	elseif INVENTORY_FRAGMENT.state == SCENE_SHOWN then  -- there should always be one or the other shown, but check both conditions to be on the safe side


### PR DESCRIPTION
missed setting new function name on original pass